### PR TITLE
extensions for irixxxx/picodrive

### DIFF
--- a/fonts.h
+++ b/fonts.h
@@ -1,6 +1,6 @@
 
 extern unsigned char fontdata8x8[64*16];
-extern unsigned char fontdata6x8[256-32][8];
+extern unsigned char fontdata6x8[256][8];
 
 void basic_text_out16_nf(void *fb, int w, int x, int y, const char *text);
 void basic_text_out16(void *fb, int w, int x, int y, const char *texto, ...);

--- a/linux/host_dasm.c
+++ b/linux/host_dasm.c
@@ -22,11 +22,31 @@ extern char **g_argv;
 
 static struct disassemble_info di;
 
-#ifdef __arm__
+#if defined __arm__
 #define print_insn_func print_insn_little_arm
 #define BFD_ARCH bfd_arch_arm
 #define BFD_MACH bfd_mach_arm_unknown
 #define DASM_OPTS "reg-names-std"
+#elif defined __aarch64__
+#define print_insn_func print_insn_aarch64
+#define BFD_ARCH bfd_arch_aarch64
+#define BFD_MACH bfd_mach_aarch64
+#define DASM_OPTS NULL
+#elif defined __mips__
+#define print_insn_func print_insn_little_mips
+#define BFD_ARCH bfd_arch_mips
+#define BFD_MACH bfd_mach_mipsisa32
+#define DASM_OPTS NULL
+#elif defined __riscv
+#define print_insn_func print_insn_riscv
+#define BFD_ARCH bfd_arch_riscv
+#define BFD_MACH bfd_mach_riscv64
+#define DASM_OPTS NULL
+#elif defined __powerpc__
+#define print_insn_func print_insn_little_powerpc
+#define BFD_ARCH bfd_arch_powerpc
+#define BFD_MACH bfd_mach_ppc64
+#define DASM_OPTS NULL
 #elif defined(__x86_64__) || defined(__i386__)
 #define print_insn_func print_insn_i386_intel
 #define BFD_ARCH bfd_arch_i386


### PR DESCRIPTION
Changes:
- fix type for fontdata6x8
- add additional disassembler platforms for new drc targets
- introduce another overlay to SDL, having twice the width while maintaining the original height. This improves the color resolution, since YUV only contains one of the 2 color components per pixel. The stretched overlay has both color components for each display pixel, for a rather modest overhead (nearly none if hardware scaling is available). It's controlled by #if, so it could be excluded on platform where it is technically not available.
