### PR TITLE
fix for loosing one-shot key events for emulator keys

### DIFF
--- a/in_sdl.c
+++ b/in_sdl.c
@@ -381,7 +381,7 @@ static int collect_events(struct in_sdl_state *state, int *one_kc, int *one_down
 			if (ret < 0) {
 				switch (ret) {
 					case -2:
-						SDL_PeepEvents(events+i, count-i, SDL_ADDEVENT, mask);
+						SDL_PushEvent(event);
 						break;
 					default:
 						if (ext_event_handler != NULL)

--- a/in_sdl.c
+++ b/in_sdl.c
@@ -381,7 +381,7 @@ static int collect_events(struct in_sdl_state *state, int *one_kc, int *one_down
 			if (ret < 0) {
 				switch (ret) {
 					case -2:
-						SDL_PushEvent(event);
+						SDL_PeepEvents(events+i, count-i, SDL_ADDEVENT, mask);
 						break;
 					default:
 						if (ext_event_handler != NULL)

--- a/input.c
+++ b/input.c
@@ -43,6 +43,9 @@ static int in_have_async_devs = 0;
 static int in_probe_dev_id;
 static int menu_key_state = 0;
 static int menu_last_used_dev = 0;
+static int menu_key_prev = 0;
+static int menu_key_mask = 0;
+static int menu_key_repeat = 0;
 
 #define DRV(id) in_drivers[id]
 
@@ -432,9 +435,9 @@ int in_menu_wait_any(char *charcode, int timeout_ms)
 {
 	int keys_old = menu_key_state;
 	int ret;
-	int is_down = 0, dev_id = 0;
+	int dev_id = 0;
 
-	in_update_keycode(&dev_id, &is_down, charcode, timeout_ms);
+	in_update_keycode(&dev_id, NULL, charcode, timeout_ms);
 
 	if (keys_old != menu_key_state)
 		menu_last_used_dev = dev_id;
@@ -447,32 +450,31 @@ int in_menu_wait_any(char *charcode, int timeout_ms)
 /* wait for menu input, do autorepeat */
 int in_menu_wait(int interesting, char *charcode, int autorep_delay_ms)
 {
-	static int inp_prev = 0;
-	static int repeats = 0;
-	int ret, release = 0, wait = 450;
+	int ret, wait = 450;
 
-	if (repeats)
+	if (menu_key_repeat)
 		wait = autorep_delay_ms;
 
-	ret = in_menu_wait_any(charcode, wait);
-	if (ret == inp_prev)
-		repeats++;
+	/* wait until either key repeat or a new key has been pressed,
+	 * mask away all old keys if an additional new key is pressed */
+	do {
+		ret = in_menu_wait_any(charcode, wait);
+		if (ret == 0) {
+			menu_key_mask = menu_key_prev = 0;
+			menu_key_repeat = 0;
+		} else 	if (ret != menu_key_prev) {
+			menu_key_mask = menu_key_prev;
+			menu_key_repeat = 0;
+		} else
+			menu_key_repeat++;
+		menu_key_prev = ret;
+		wait = -1;
+	} while (!(ret & ~menu_key_mask & interesting));
 
-	while (!(ret & interesting)) {
-		ret = in_menu_wait_any(charcode, -1);
-		release = 1;
-	}
-
-	if (release || ret != inp_prev)
-		repeats = 0;
-
-	inp_prev = ret;
+	ret &= ~menu_key_mask;
 
 	/* we don't need diagonals in menus */
-	if ((ret & PBTN_UP)   && (ret & PBTN_LEFT))  ret &= ~PBTN_LEFT;
-	if ((ret & PBTN_UP)   && (ret & PBTN_RIGHT)) ret &= ~PBTN_RIGHT;
-	if ((ret & PBTN_DOWN) && (ret & PBTN_LEFT))  ret &= ~PBTN_LEFT;
-	if ((ret & PBTN_DOWN) && (ret & PBTN_RIGHT)) ret &= ~PBTN_RIGHT;
+	if (ret & (PBTN_UP|PBTN_DOWN))  ret &= ~(PBTN_LEFT|PBTN_RIGHT);
 
 	return ret;
 }

--- a/input.c
+++ b/input.c
@@ -432,20 +432,12 @@ int in_menu_wait_any(char *charcode, int timeout_ms)
 {
 	int keys_old = menu_key_state;
 	int ret;
+	int is_down = 0, dev_id = 0;
 
-	while (1)
-	{
-		int code, is_down = 0, dev_id = 0;
+	in_update_keycode(&dev_id, &is_down, charcode, timeout_ms);
 
-		code = in_update_keycode(&dev_id, &is_down, charcode, timeout_ms);
-		if (code < 0)
-			break;
-
-		if (keys_old != menu_key_state) {
-			menu_last_used_dev = dev_id;
-			break;
-		}
-	}
+	if (keys_old != menu_key_state)
+		menu_last_used_dev = dev_id;
 
 	ret = menu_key_state;
 	menu_key_state &= ~PBTN_CHAR;
@@ -548,12 +540,12 @@ static int in_set_blocking(int is_blocking)
 		}
 	}
 
-	menu_key_state = 0;
-
 	/* flush events */
 	do {
 		ret = in_update_keycode(NULL, NULL, NULL, 0);
 	} while (ret >= 0);
+
+	menu_key_state = 0;
 
 	return 0;
 }


### PR DESCRIPTION
The input event handling code looses key press events if both the key pressed and released events are sent at the same time. This can be the case for one-shot keys, e.g. the POWER key on RG350 and the function keys on the touch bar of a macbook.

While this doesn't matter for keys mapped to a console pad, it can be annoying for keys providing emulator functions, e.g. saving, loading, save slot selection etc pp. To circumvent this, all unprocessed events are stuffed back into the event queue and event processing is stopped for the current turn if an event for a key with an emulator function is detected.

Please do a review and check if this is colliding with other users of libpicofe. Based on a quick code review I think pcsx rearmed should be ok. However, I believe it should resolve the same problem for others as well.
