### PR TITLE
sdl: lock YUV overlay before clearing

### DIFF
--- a/plat_sdl.c
+++ b/plat_sdl.c
@@ -101,11 +101,13 @@ int plat_sdl_change_video_mode(int w, int h, int force)
       || plat_target.vout_method == vout_mode_overlay2x) {
     int W = plat_target.vout_method == vout_mode_overlay2x && w == 320 ? 2*w : w;
     plat_sdl_overlay = SDL_CreateYUVOverlay(W, h, SDL_UYVY_OVERLAY, plat_sdl_screen);
-    if (plat_sdl_overlay != NULL) {
+    if (plat_sdl_overlay != NULL && SDL_LockYUVOverlay(plat_sdl_overlay) == 0) {
       if ((long)plat_sdl_overlay->pixels[0] & 3)
         fprintf(stderr, "warning: overlay pointer is unaligned\n");
 
       plat_sdl_overlay_clear();
+
+      SDL_UnlockYUVOverlay(plat_sdl_overlay);
     }
     else {
       fprintf(stderr, "warning: could not create overlay.\n");


### PR DESCRIPTION
Running a newly built PicoDrive on Fedora 35 x86_64:
```
plat_sdl: using 1920x1080 as fullscreen resolution
plat_sdl: overlay: fmt 59565955, planes: 1, pitch: 1280, hw: 1
Segmentation fault (core dumped)
```